### PR TITLE
fixed comparison to None with !=

### DIFF
--- a/cassowary/simplex_solver.py
+++ b/cassowary/simplex_solver.py
@@ -381,7 +381,7 @@ class SimplexSolver(Tableau):
             raise RequiredFailure()
 
         e = self.rows.get(av)
-        if e != None:
+        if e is not None:
             # print("av exists")
             if e.is_constant:
                 # print("av is constant")


### PR DESCRIPTION
This caused random failures with [Vispy](https://github.com/vispy/vispy/pull/1049#discussion_r48691905) on using Cassowary.

changing `e != None` to `e is not None` fixed it, since we're checking for object identity and not object equality